### PR TITLE
feat: add domain validation to prevent unauthorized access

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,22 @@ clearSecret();
 
 ### Server API (`zerokey/server`)
 
-#### `initSecretServer(): void`
+#### `initSecretServer(options?: SecretServerOptions): void`
 
 Initializes the server handler on the auth domain. Parses query parameters and prepares for secret transfer.
 
 ```javascript
-// Call this when your auth page loads
+// Basic usage
 initSecretServer();
+
+// With domain validation for enhanced security
+initSecretServer({
+  validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
+});
 ```
+
+**Options:**
+- `validateCallbackUrl?: (url: string) => boolean` - Optional callback to validate redirect URLs. This provides protection against unauthorized domains requesting secrets.
 
 #### `setSecret(secret: string): void`
 
@@ -118,6 +126,32 @@ setSecret(encryptionKey);
 3. **Auto-Expiry**: Pending keys expire after 5 minutes
 4. **CSRF Protection**: State parameter prevents replay attacks
 5. **HTTPS Required**: Always use HTTPS in production
+6. **Domain Validation**: Use `validateCallbackUrl` to restrict which domains can request secrets
+
+### Preventing Unauthorized Access
+
+By default, any domain can request a secret from your auth server. To prevent malicious sites from obtaining secrets, use the `validateCallbackUrl` option:
+
+```javascript
+// Only allow your specific app domain
+initSecretServer({
+  validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
+});
+
+// Allow multiple trusted domains
+initSecretServer({
+  validateCallbackUrl: (url) => {
+    const trustedDomains = [
+      'https://app.example.com',
+      'https://staging.example.com',
+      'http://localhost:3000' // for development only - always use HTTPS in production
+    ];
+    return trustedDomains.some(domain => url.startsWith(domain));
+  }
+});
+```
+
+This prevents scenarios where `dodgysite.com` could redirect users to your auth server and attempt to obtain their secrets.
 
 ## Testing
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -78,14 +78,14 @@ interface SecretServerOptions {
    * If provided, must return true for the URL to be accepted.
    * This provides an additional security layer to prevent unauthorized domains
    * from requesting secrets.
-   * 
+   *
    * @param url - The redirect URL to validate
    * @returns True if the URL should be allowed, false otherwise
-   * 
+   *
    * @example
    * // Only allow specific domain
    * validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
-   * 
+   *
    * @example
    * // Allow multiple domains
    * validateCallbackUrl: (url) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,33 @@ interface ZerokeyParams {
 }
 
 /**
+ * Configuration options for the secret server.
+ */
+interface SecretServerOptions {
+  /**
+   * Optional callback to validate the redirect URL.
+   * If provided, must return true for the URL to be accepted.
+   * This provides an additional security layer to prevent unauthorized domains
+   * from requesting secrets.
+   * 
+   * @param url - The redirect URL to validate
+   * @returns True if the URL should be allowed, false otherwise
+   * 
+   * @example
+   * // Only allow specific domain
+   * validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
+   * 
+   * @example
+   * // Allow multiple domains
+   * validateCallbackUrl: (url) => {
+   *   const allowed = ['https://app1.com', 'https://app2.com'];
+   *   return allowed.some(domain => url.startsWith(domain));
+   * }
+   */
+  validateCallbackUrl?: (url: string) => boolean;
+}
+
+/**
  * Global window extension to store validated zerokey parameters.
  * This allows the parameters to persist between initialization and secret setting.
  */
@@ -187,24 +214,40 @@ async function performRedirect(
  * If a secret has already been set via `setSecret()` before initialization,
  * it will immediately process and redirect with the encrypted secret.
  *
+ * @param {SecretServerOptions} options - Optional configuration for the secret server
+ * @param {Function} options.validateCallbackUrl - Optional callback to validate redirect URLs
  * @returns {void}
  *
  * @throws {Error} Logs errors if required parameters are missing or invalid
  *
  * @example
- * // On page load of the secret server:
+ * // Basic initialization
  * import { initSecretServer } from 'zerokey/server';
  *
- * // Initialize when DOM is ready
  * document.addEventListener('DOMContentLoaded', () => {
  *   initSecretServer();
  * });
  *
  * @example
- * // URL: https://secrets.example.com?publicKey=...&redirect=https://app.com&state=abc123
- * initSecretServer(); // Parses params and prepares for secret input
+ * // With domain validation for security
+ * initSecretServer({
+ *   validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
+ * });
+ *
+ * @example
+ * // Allow multiple trusted domains
+ * initSecretServer({
+ *   validateCallbackUrl: (url) => {
+ *     const trustedDomains = [
+ *       'https://app.example.com',
+ *       'https://staging.example.com',
+ *       'http://localhost:3000' // for development
+ *     ];
+ *     return trustedDomains.some(domain => url.startsWith(domain));
+ *   }
+ * });
  */
-export function initSecretServer(): void {
+export function initSecretServer(options: SecretServerOptions = {}): void {
   if (isInitialized) {
     console.warn('Secret server already initialized');
     return;
@@ -223,6 +266,12 @@ export function initSecretServer(): void {
 
   if (!isValidRedirect(redirect)) {
     console.error('Invalid redirect URL');
+    return;
+  }
+
+  // Apply custom validation if provided
+  if (options.validateCallbackUrl && !options.validateCallbackUrl(redirect)) {
+    console.error('Redirect URL failed custom validation');
     return;
   }
 

--- a/tests/fixtures/auth-server.js
+++ b/tests/fixtures/auth-server.js
@@ -11,6 +11,15 @@ const PORT = 3002;
 // Serve static files from the root directory
 app.use(express.static(join(__dirname, '../..')));
 
+// Serve validation test pages
+app.get('/validation-test.html', (req, res) => {
+  res.sendFile(join(__dirname, 'validation-test.html'));
+});
+
+app.get('/validation-logging.html', (req, res) => {
+  res.sendFile(join(__dirname, 'validation-logging.html'));
+});
+
 // Serve the auth test page
 app.get('/', (req, res) => {
   res.send(`

--- a/tests/fixtures/validation-logging.html
+++ b/tests/fixtures/validation-logging.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Validation Logging Test - Zerokey</title>
+  <meta charset="utf-8">
+</head>
+<body>
+  <h1>Validation Logging Test</h1>
+  <div id="status">Initializing...</div>
+  <div id="logged-url"></div>
+  
+  <script type="module">
+    import { initSecretServer } from '/server.js';
+
+    const statusEl = document.getElementById('status');
+    const loggedUrlEl = document.getElementById('logged-url');
+
+    try {
+      // Initialize with validation that logs the URL
+      initSecretServer({
+        validateCallbackUrl: (url) => {
+          loggedUrlEl.textContent = url;
+          return true; // Allow all for logging test
+        }
+      });
+
+      statusEl.textContent = 'Initialized with logging';
+    } catch (error) {
+      statusEl.textContent = 'Error: ' + error.message;
+    }
+  </script>
+</body>
+</html>

--- a/tests/fixtures/validation-test.html
+++ b/tests/fixtures/validation-test.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Validation Test - Zerokey</title>
+  <meta charset="utf-8">
+</head>
+<body>
+  <h1>Validation Test</h1>
+  <div id="status">Initializing...</div>
+  
+  <script type="module">
+    import { initSecretServer } from '/server.js';
+
+    const statusEl = document.getElementById('status');
+    
+    // Capture console errors
+    const originalError = console.error;
+    console.error = function(...args) {
+      originalError.apply(console, args);
+      // Display validation errors in the status
+      if (args[0] === 'Redirect URL failed custom validation') {
+        statusEl.textContent = 'Redirect URL failed custom validation';
+      }
+    };
+
+    try {
+      // Initialize with domain validation
+      initSecretServer({
+        validateCallbackUrl: (url) => {
+          // Only allow localhost:3001 (our app domain)
+          return url.startsWith('http://localhost:3001');
+        }
+      });
+
+      // Check if we have params
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('publicKey') && params.get('redirect') && params.get('state')) {
+        // If we got here, validation passed
+        if (statusEl.textContent !== 'Redirect URL failed custom validation') {
+          statusEl.textContent = 'Secret request received!';
+        }
+      } else {
+        statusEl.textContent = 'Waiting for secret request...';
+      }
+    } catch (error) {
+      statusEl.textContent = 'Error: ' + error.message;
+    }
+  </script>
+</body>
+</html>

--- a/tests/validation.spec.js
+++ b/tests/validation.spec.js
@@ -13,17 +13,19 @@ test.describe('Zerokey Domain Validation', () => {
   test('rejects unauthorized domains with validateCallbackUrl', async ({ page }) => {
     // Create auth page with validation
     await page.goto(`${AUTH_URL}/validation-test.html`);
-    
+
     // Check that the page loaded correctly
     await expect(page.locator('h1')).toContainText('Validation Test');
-    
+
     // Try to request with unauthorized domain
     const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
     const state = 'test-state';
-    
+
     // Navigate with malicious redirect URL
-    await page.goto(`${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(MALICIOUS_URL)}&state=${state}`);
-    
+    await page.goto(
+      `${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(MALICIOUS_URL)}&state=${state}`
+    );
+
     // Verify error is shown
     await expect(page.locator('#status')).toContainText('Redirect URL failed custom validation');
   });
@@ -31,17 +33,19 @@ test.describe('Zerokey Domain Validation', () => {
   test('allows authorized domains with validateCallbackUrl', async ({ page }) => {
     // Create auth page with validation
     await page.goto(`${AUTH_URL}/validation-test.html`);
-    
+
     // Check that the page loaded correctly
     await expect(page.locator('h1')).toContainText('Validation Test');
-    
+
     // Try to request with authorized domain
     const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
     const state = 'test-state';
-    
+
     // Navigate with allowed redirect URL
-    await page.goto(`${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(APP_URL)}&state=${state}`);
-    
+    await page.goto(
+      `${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(APP_URL)}&state=${state}`
+    );
+
     // Verify success
     await expect(page.locator('#status')).toContainText('Secret request received!');
   });
@@ -49,13 +53,15 @@ test.describe('Zerokey Domain Validation', () => {
   test('validation function receives correct URL', async ({ page }) => {
     // This test verifies the URL passed to validateCallbackUrl is correct
     await page.goto(`${AUTH_URL}/validation-logging.html`);
-    
+
     const testUrl = 'https://example.com/callback?foo=bar';
     const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
     const state = 'test-state';
-    
-    await page.goto(`${AUTH_URL}/validation-logging.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(testUrl)}&state=${state}`);
-    
+
+    await page.goto(
+      `${AUTH_URL}/validation-logging.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(testUrl)}&state=${state}`
+    );
+
     // Check that the logged URL matches what was passed
     const loggedUrl = await page.locator('#logged-url').textContent();
     expect(loggedUrl).toBe(testUrl);

--- a/tests/validation.spec.js
+++ b/tests/validation.spec.js
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Zerokey Domain Validation', () => {
+  const APP_URL = 'http://localhost:3001';
+  const AUTH_URL = 'http://localhost:3002';
+  const MALICIOUS_URL = 'http://malicious.com';
+
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    await context.clearPermissions();
+  });
+
+  test('rejects unauthorized domains with validateCallbackUrl', async ({ page }) => {
+    // Create auth page with validation
+    await page.goto(`${AUTH_URL}/validation-test.html`);
+    
+    // Check that the page loaded correctly
+    await expect(page.locator('h1')).toContainText('Validation Test');
+    
+    // Try to request with unauthorized domain
+    const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
+    const state = 'test-state';
+    
+    // Navigate with malicious redirect URL
+    await page.goto(`${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(MALICIOUS_URL)}&state=${state}`);
+    
+    // Verify error is shown
+    await expect(page.locator('#status')).toContainText('Redirect URL failed custom validation');
+  });
+
+  test('allows authorized domains with validateCallbackUrl', async ({ page }) => {
+    // Create auth page with validation
+    await page.goto(`${AUTH_URL}/validation-test.html`);
+    
+    // Check that the page loaded correctly
+    await expect(page.locator('h1')).toContainText('Validation Test');
+    
+    // Try to request with authorized domain
+    const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
+    const state = 'test-state';
+    
+    // Navigate with allowed redirect URL
+    await page.goto(`${AUTH_URL}/validation-test.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(APP_URL)}&state=${state}`);
+    
+    // Verify success
+    await expect(page.locator('#status')).toContainText('Secret request received!');
+  });
+
+  test('validation function receives correct URL', async ({ page }) => {
+    // This test verifies the URL passed to validateCallbackUrl is correct
+    await page.goto(`${AUTH_URL}/validation-logging.html`);
+    
+    const testUrl = 'https://example.com/callback?foo=bar';
+    const publicKey = '-----BEGIN PUBLIC KEY-----test-key-----END PUBLIC KEY-----';
+    const state = 'test-state';
+    
+    await page.goto(`${AUTH_URL}/validation-logging.html?publicKey=${encodeURIComponent(publicKey)}&redirect=${encodeURIComponent(testUrl)}&state=${state}`);
+    
+    // Check that the logged URL matches what was passed
+    const loggedUrl = await page.locator('#logged-url').textContent();
+    expect(loggedUrl).toBe(testUrl);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `validateCallbackUrl` option to `initSecretServer()` for domain validation
- Prevent unauthorized domains from requesting secrets
- Add comprehensive tests and documentation

## Motivation
Previously, any domain could request secrets from the auth server by redirecting users with the appropriate parameters. This posed a security risk where malicious sites could potentially obtain user secrets.

## Changes
- Added `SecretServerOptions` interface with `validateCallbackUrl` callback
- Implemented validation check before processing redirect URLs
- Added Playwright tests to verify domain restrictions work correctly
- Updated documentation with security best practices

## Usage
```javascript
// Only allow specific domain
initSecretServer({
  validateCallbackUrl: (url) => url.startsWith('https://myapp.com')
});
```

## Test plan
- [x] Added validation.spec.js with tests for authorized/unauthorized domains
- [x] Verified validation callback receives correct URL
- [x] All existing tests still pass
- [x] Build completes successfully